### PR TITLE
Add badge to the README file and remove brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-https://github.com/<noazaj>/<learn-ccid-starter>/actions/workflows/<ci.yml>/badge.svg
+https://github.com/noazaj/learn-ccid-starter/actions/workflows/ci.yml/badge.svg
 
 # learn-cicd-starter (Notely)
 


### PR DESCRIPTION
Fix badge showing by removing brackets in URL